### PR TITLE
🔧  Add builder app command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+dist

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "tsx watch src/server.ts",
-    "build": "tsc src/server.ts"
+    "build": "npx tsc"
   },
   "author": "",
   "license": "ISC",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,7 +57,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */


### PR DESCRIPTION
# 🔧  Add builder app command

## Motivation
In order to support the deploy process we are adding a build command that generates the output files in a `./dist` folder

## Changes
- adjust tsconfig file
- add build command on package.json
- update gitignore