### PR TITLE
💚 Exclude files during Ts build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -106,5 +106,11 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests",
+    "**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
# 💚 Exclude files during Ts build

## Motivation
After adding tests it was creating both `src` and `test` folders in `./dist` so it wasnt possible to locate `server.js` file to start the application 

## Changes
- add exclude config to `tsconfig.json` file