### PR TITLE
🚚 Rename queue handler to lobby handler

### DIFF
--- a/src/handlers/connectionHandler.ts
+++ b/src/handlers/connectionHandler.ts
@@ -11,7 +11,7 @@ export function registerConnectionHandlers(io: Server, socket: Socket) {
 
     const athletes = queueService.leave(socket.id);
 
-    io.emit("queue:list", athletes);
+    io.emit("lobby:list", athletes);
   }
 
   socket.on("disconnect", disconnect);

--- a/src/handlers/courtHandler.ts
+++ b/src/handlers/courtHandler.ts
@@ -22,7 +22,7 @@ export function registerCourtHandlers(io: Server, socket: Socket) {
 
     const athletes = queueService.leave(player.id);
 
-    io.emit("queue:list", athletes);
+    io.emit("lobby:list", athletes);
   }
 
   function leave(data: CourtPayload) {
@@ -37,7 +37,7 @@ export function registerCourtHandlers(io: Server, socket: Socket) {
 
     const athletes = queueService.join(player);
 
-    io.emit("queue:list", athletes);
+    io.emit("lobby:list", athletes);
   }
 
   socket.on("court:join", join);

--- a/src/handlers/handlers.test.ts
+++ b/src/handlers/handlers.test.ts
@@ -31,9 +31,9 @@ describe("Handlers", () => {
 
   describe("Queue Handler", () => {
     it("should join the queue", async () => {
-      clientSocket.emit("queue:join", { name: "expensive player" });
+      clientSocket.emit("lobby:join", { name: "expensive player" });
 
-      const queue = await waitForEventToBeEmitted(clientSocket, "queue:list");
+      const queue = await waitForEventToBeEmitted(clientSocket, "lobby:list");
 
       expect(queue).toEqual([
         { id: serverSocket?.id, name: "expensive player" },
@@ -41,9 +41,9 @@ describe("Handlers", () => {
     });
 
     it("should leave the queue", async () => {
-      clientSocket.emit("queue:leave", { name: "expensive player" });
+      clientSocket.emit("lobby:leave", { name: "expensive player" });
 
-      const queue = await waitForEventToBeEmitted(clientSocket, "queue:list");
+      const queue = await waitForEventToBeEmitted(clientSocket, "lobby:list");
 
       expect(queue).toEqual([]);
     });

--- a/src/handlers/lobbyHandler.ts
+++ b/src/handlers/lobbyHandler.ts
@@ -8,7 +8,7 @@ interface QueuePayload {
   name: string;
 }
 
-export function registerQueueHandlers(io: Server, socket: Socket) {
+export function registerLobbyHandlers(io: Server, socket: Socket) {
   function join(data: QueuePayload) {
     const athlete: Athlete = {
       id: socket.id,
@@ -17,15 +17,15 @@ export function registerQueueHandlers(io: Server, socket: Socket) {
 
     const athletes = queueService.join(athlete);
 
-    io.emit("queue:list", athletes);
+    io.emit("lobby:list", athletes);
   }
 
   function leave() {
     const athletes = queueService.leave(socket.id);
 
-    io.emit("queue:list", athletes);
+    io.emit("lobby:list", athletes);
   }
 
-  socket.on("queue:join", join);
-  socket.on("queue:leave", leave);
+  socket.on("lobby:join", join);
+  socket.on("lobby:leave", leave);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import { Server } from "socket.io";
 import { createServer } from "http";
 
-import { registerQueueHandlers } from "./handlers/queueHandler.js";
+import { registerLobbyHandlers } from "./handlers/lobbyHandler.js";
 import { registerCourtHandlers } from "./handlers/courtHandler.js";
 import { registerConnectionHandlers } from "./handlers/connectionHandler.js";
 
@@ -12,7 +12,7 @@ const io = new Server(httpServer, {
 });
 
 io.on("connection", (socket) => {
-  registerQueueHandlers(io, socket);
+  registerLobbyHandlers(io, socket);
   registerCourtHandlers(io, socket);
   registerConnectionHandlers(io, socket);
 });

--- a/tests/utils/server.ts
+++ b/tests/utils/server.ts
@@ -3,7 +3,7 @@ import { createServer } from "http";
 import { Server, Socket } from "socket.io";
 import { Socket as ClientSocket, io as ioc } from "socket.io-client";
 
-import { registerQueueHandlers } from "../../src/handlers/queueHandler.js";
+import { registerLobbyHandlers } from "../../src/handlers/lobbyHandler.js";
 import { registerCourtHandlers } from "../../src/handlers/courtHandler.js";
 import { registerConnectionHandlers } from "../../src/handlers/connectionHandler.js";
 
@@ -29,7 +29,7 @@ export async function setupTestServer(port: number) {
   io.on("connection", (connectedSocket) => {
     serverSocket = connectedSocket;
 
-    registerQueueHandlers(io, serverSocket);
+    registerLobbyHandlers(io, serverSocket);
     registerCourtHandlers(io, serverSocket);
     registerConnectionHandlers(io, serverSocket);
   });


### PR DESCRIPTION
# 🚚 Rename queue handler to lobby handler

## Motivation
In order to support the UI page that is going to list people waiting to play and people playing, we are changing the concept to lobby

## Changes
- update event name to `lobby:*`
- rename the handler file
- update tests