### PR TITLE
✨  Add estimated time to next game in lobby info

### DIFF
--- a/src/handlers/handlers.test.ts
+++ b/src/handlers/handlers.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { Server, Socket } from "socket.io";
 import { Socket as ClientSocket } from "socket.io-client";
@@ -7,6 +7,15 @@ import {
   setupTestServer,
   waitForEventToBeEmitted,
 } from "../../tests/utils/server.js";
+
+vi.mock("../libraries/date.js", () => {
+  return {
+    now: vi.fn(),
+    addMinutes: vi.fn().mockReturnValue({
+      toJSDate: vi.fn().mockReturnValue("2023-07-14T00:00:00.000Z"),
+    }),
+  };
+});
 
 describe("Handlers", () => {
   let io: Server;
@@ -38,6 +47,7 @@ describe("Handlers", () => {
       expect(queue).toEqual({
         atheletes: [{ id: serverSocket?.id, name: "expensive player" }],
         court: [],
+        nextGameDate: "2023-07-14T00:00:00.000Z",
       });
     });
 
@@ -49,6 +59,7 @@ describe("Handlers", () => {
       expect(queue).toEqual({
         atheletes: [],
         court: [],
+        nextGameDate: "2023-07-14T00:00:00.000Z",
       });
     });
   });
@@ -62,6 +73,7 @@ describe("Handlers", () => {
       expect(court).toEqual({
         atheletes: [],
         court: [{ id: serverSocket?.id, name: "expensive player" }],
+        nextGameDate: "2023-07-14T00:00:00.000Z",
       });
     });
 
@@ -73,6 +85,7 @@ describe("Handlers", () => {
       expect(queue).toEqual({
         atheletes: [{ id: serverSocket?.id, name: "expensive player" }],
         court: [],
+        nextGameDate: "2023-07-14T00:00:00.000Z",
       });
     });
   });

--- a/src/services/lobbyService.test.ts
+++ b/src/services/lobbyService.test.ts
@@ -52,6 +52,7 @@ describe("Lobby Service", () => {
     expect(preview).toEqual({
       court: [{ id: "connection-id", name: "expensive player in game" }],
       atheletes: [{ id: "connection-id", name: "expensive player waiting" }],
+      nextGameDate: "2023-07-14T00:00:00.000Z",
     });
   });
 });

--- a/src/services/lobbyService.ts
+++ b/src/services/lobbyService.ts
@@ -8,14 +8,18 @@ import { courtRepository } from "../repositories/courtRepository.js";
 const ATHLETES_PER_GAME = 4;
 const AVG_GAME_TIME_MINUTES = 20;
 
-function getPreview() {
-  const queueSize = athleteRepository.size();
-
+function calculateNextGameDate(queueSize: number) {
   const gamesCount = Math.floor(queueSize / ATHLETES_PER_GAME);
 
   const minutesUntilNextGame = gamesCount * AVG_GAME_TIME_MINUTES;
 
-  const nextGameDate = addMinutes(now(), minutesUntilNextGame).toJSDate();
+  return addMinutes(now(), minutesUntilNextGame).toJSDate();
+}
+
+function getPreview() {
+  const queueSize = athleteRepository.size();
+
+  const nextGameDate = calculateNextGameDate(queueSize);
 
   const lobbyPreview: LobbyPreview = { queueSize, nextGameDate };
 
@@ -27,7 +31,11 @@ function getList() {
 
   const atheletes = athleteRepository.list();
 
-  return { court, atheletes };
+  const queueSize = athleteRepository.size();
+
+  const nextGameDate = calculateNextGameDate(queueSize);
+
+  return { atheletes, court, nextGameDate };
 }
 
 export const lobbyService = {


### PR DESCRIPTION
# ✨  Add estimated time to next game in lobby info

## Motivation
After the user joins the lobby we want to show the estimated time until the next game

## Changes
- create a function to calculate the next game date
- apply the function on `getPreview`
- apply the function on `getList`
- add tests
