### PR TITLE
✨ Add next game event

### DIFF
--- a/src/handlers/events.ts
+++ b/src/handlers/events.ts
@@ -9,6 +9,7 @@ export const court = {
   list: "court:list",
   join: "court:join",
   leave: "court:leave",
+  nextGame: "court:next-game",
 };
 
 export const server = {

--- a/src/handlers/handlers.test.ts
+++ b/src/handlers/handlers.test.ts
@@ -10,8 +10,9 @@ import {
 
 const lobbyServiceGetListMock = vi.fn();
 
-const nextGameServiceGetPlayersMock = vi.fn();
 const nextGameServiceHasGameAvailableMock = vi.fn();
+
+const queueServiceGetFirstFourMock = vi.fn();
 
 vi.mock("../libraries/date.js", () => {
   return {
@@ -27,6 +28,7 @@ vi.mock("../services/queueService.js", () => {
     queueService: {
       join: vi.fn(),
       leave: vi.fn(),
+      getFirstFour: () => queueServiceGetFirstFourMock(),
     },
   };
 });
@@ -42,7 +44,6 @@ vi.mock("../services/lobbyService.js", () => {
 vi.mock("../services/nextGameService.js", () => {
   return {
     nextGameService: {
-      getPlayers: () => nextGameServiceGetPlayersMock(),
       hasGameAvailable: () => nextGameServiceHasGameAvailableMock(),
     },
   };
@@ -118,7 +119,7 @@ describe("Handlers", () => {
         nextGameDate: "2023-07-14T00:00:00.000Z",
       });
 
-      nextGameServiceGetPlayersMock.mockReturnValue([
+      queueServiceGetFirstFourMock.mockReturnValue([
         { name: "first" },
         { name: "second" },
         { name: "third" },

--- a/src/handlers/handlers.test.ts
+++ b/src/handlers/handlers.test.ts
@@ -113,7 +113,7 @@ describe("Handlers", () => {
           { name: "second" },
           { name: "third" },
           { name: "fourth" },
-          { name: "fifth" },
+          { name: "expensive player" },
         ],
         court: [],
         nextGameDate: "2023-07-14T00:00:00.000Z",

--- a/src/handlers/handlers.test.ts
+++ b/src/handlers/handlers.test.ts
@@ -103,7 +103,7 @@ describe("Handlers", () => {
       });
     });
 
-    it.only("should emit the next-game event when join the lobby", async () => {
+    it("should emit the next-game event when join the lobby", async () => {
       nextGameServiceHasGameAvailableMock.mockReturnValue(true);
 
       lobbyServiceGetListMock.mockReturnValue({

--- a/src/handlers/handlers.test.ts
+++ b/src/handlers/handlers.test.ts
@@ -102,6 +102,43 @@ describe("Handlers", () => {
         nextGameDate: "2023-07-14T00:00:00.000Z",
       });
     });
+
+    it.only("should emit the next-game event when join the lobby", async () => {
+      nextGameServiceHasGameAvailableMock.mockReturnValue(true);
+
+      lobbyServiceGetListMock.mockReturnValue({
+        atheletes: [
+          { name: "first" },
+          { name: "second" },
+          { name: "third" },
+          { name: "fourth" },
+          { name: "fifth" },
+        ],
+        court: [],
+        nextGameDate: "2023-07-14T00:00:00.000Z",
+      });
+
+      nextGameServiceGetPlayersMock.mockReturnValue([
+        { name: "first" },
+        { name: "second" },
+        { name: "third" },
+        { name: "fourth" },
+      ]);
+
+      clientSocket.emit("lobby:join", { name: "expensive player" });
+
+      const nextGame = await waitForEventToBeEmitted(
+        clientSocket,
+        "court:next-game"
+      );
+
+      expect(nextGame).toEqual([
+        { name: "first" },
+        { name: "second" },
+        { name: "third" },
+        { name: "fourth" },
+      ]);
+    });
   });
 
   describe("Court Handler", () => {

--- a/src/handlers/lobbyHandler.ts
+++ b/src/handlers/lobbyHandler.ts
@@ -4,8 +4,9 @@ import { Athlete } from "../models/athleteModel.js";
 
 import { queueService } from "../services/queueService.js";
 import { lobbyService } from "../services/lobbyService.js";
+import { nextGameService } from "../services/nextGameService.js";
 
-import { lobby } from "./events.js";
+import { court, lobby } from "./events.js";
 
 interface QueuePayload {
   name: string;
@@ -21,13 +22,19 @@ export function registerLobbyHandlers(io: Server, socket: Socket) {
     queueService.join(athlete);
 
     const lobbyList = lobbyService.getList();
-    
+
     io.emit(lobby.list, lobbyList);
+
+    if (nextGameService.hasGameAvailable()) {
+      const nextGamePlayers = nextGameService.getPlayers();
+
+      io.emit(court.nextGame, nextGamePlayers);
+    }
   }
-  
+
   function leave() {
     queueService.leave(socket.id);
-    
+
     const lobbyList = lobbyService.getList();
 
     io.emit(lobby.list, lobbyList);

--- a/src/handlers/lobbyHandler.ts
+++ b/src/handlers/lobbyHandler.ts
@@ -26,7 +26,7 @@ export function registerLobbyHandlers(io: Server, socket: Socket) {
     io.emit(lobby.list, lobbyList);
 
     if (nextGameService.hasGameAvailable()) {
-      const nextGamePlayers = nextGameService.getPlayers();
+      const nextGamePlayers = queueService.getFirstFour();
 
       io.emit(court.nextGame, nextGamePlayers);
     }

--- a/src/services/nextGameService.test.ts
+++ b/src/services/nextGameService.test.ts
@@ -53,24 +53,4 @@ describe("Next Game Service", () => {
 
     expect(response).toBeFalsy();
   });
-
-  test("should return the first fourth player in queue for the next game", () => {
-    atheleteListMock.mockReturnValue([
-      { name: "first" },
-      { name: "second" },
-      { name: "third" },
-      { name: "fourth" },
-      { name: "fifth" },
-      { name: "sixth" },
-    ]);
-
-    const response = nextGameService.getPlayers();
-
-    expect(response).toEqual([
-      { name: "first" },
-      { name: "second" },
-      { name: "third" },
-      { name: "fourth" },
-    ]);
-  });
 });

--- a/src/services/nextGameService.test.ts
+++ b/src/services/nextGameService.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { nextGameService } from "./nextGameService";
+
+const atheleteListMock = vi.fn();
+
+const courtListMock = vi.fn();
+
+vi.mock("../repositories/athleteRepository.js", () => {
+  return {
+    athleteRepository: {
+      list: () => atheleteListMock(),
+    },
+  };
+});
+
+vi.mock("../repositories/courtRepository.js", () => {
+  return {
+    courtRepository: {
+      list: () => courtListMock(),
+    },
+  };
+});
+
+describe("Next Game Service", () => {
+  test("should return true for next game available", () => {
+    courtListMock.mockReturnValue([]);
+
+    atheleteListMock.mockReturnValue([
+      { name: "first" },
+      { name: "second" },
+      { name: "third" },
+      { name: "fourth" },
+      { name: "fifth" },
+    ]);
+
+    const response = nextGameService.hasGameAvailable();
+
+    expect(response).toBeTruthy();
+  });
+
+  test("should return false for next game available", () => {
+    courtListMock.mockReturnValue([
+      { name: "first" },
+      { name: "second" },
+      { name: "third" },
+      { name: "fourth" },
+    ]);
+
+    atheleteListMock.mockReturnValue([{ name: "fifth" }, { name: "sixth" }]);
+
+    const response = nextGameService.hasGameAvailable();
+
+    expect(response).toBeFalsy();
+  });
+
+  test("should return the first fourth player in queue for the next game", () => {
+    atheleteListMock.mockReturnValue([
+      { name: "first" },
+      { name: "second" },
+      { name: "third" },
+      { name: "fourth" },
+      { name: "fifth" },
+      { name: "sixth" },
+    ]);
+
+    const response = nextGameService.getPlayers();
+
+    expect(response).toEqual([
+      { name: "first" },
+      { name: "second" },
+      { name: "third" },
+      { name: "fourth" },
+    ]);
+  });
+});

--- a/src/services/nextGameService.ts
+++ b/src/services/nextGameService.ts
@@ -1,0 +1,29 @@
+import { athleteRepository } from "../repositories/athleteRepository.js";
+import { courtRepository } from "../repositories/courtRepository.js";
+
+function hasGameAvailable() {
+  const court = courtRepository.list();
+
+  const queue = athleteRepository.list();
+
+  const hasCourtAvailable = court.length === 0;
+
+  const hasEnoughPlayers = queue.length >= 4;
+
+  return hasCourtAvailable && hasEnoughPlayers;
+}
+
+function getPlayers() {
+  const queue = athleteRepository.list();
+
+  const [first, second, third, fourth] = queue;
+
+  const players = [first, second, third, fourth];
+
+  return players;
+}
+
+export const nextGameService = {
+  hasGameAvailable,
+  getPlayers,
+};

--- a/src/services/nextGameService.ts
+++ b/src/services/nextGameService.ts
@@ -13,17 +13,6 @@ function hasGameAvailable() {
   return hasCourtAvailable && hasEnoughPlayers;
 }
 
-function getPlayers() {
-  const queue = athleteRepository.list();
-
-  const [first, second, third, fourth] = queue;
-
-  const players = [first, second, third, fourth];
-
-  return players;
-}
-
 export const nextGameService = {
   hasGameAvailable,
-  getPlayers,
 };

--- a/src/services/queueService.test.ts
+++ b/src/services/queueService.test.ts
@@ -1,17 +1,55 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 
 import { queueService } from "./queueService.js";
+import { Athlete } from "../models/athleteModel.js";
+
+const atheleteRepositoryListMock = vi.fn();
+const atheleteRepositoryAddMock = vi.fn();
+const atheleteRepositoryRemoveMock = vi.fn();
+
+vi.mock("../repositories/athleteRepository.js", () => {
+  return {
+    athleteRepository: {
+      list: () => atheleteRepositoryListMock(),
+      add: (athelete: Athlete) => atheleteRepositoryAddMock(athelete),
+      remove: (id: string) => atheleteRepositoryRemoveMock(id),
+    },
+  };
+});
 
 describe("Queue Service", () => {
   test("should add an athlete in queue list", () => {
-    const result = queueService.join({ id: "999", name: "expensive player" });
+    queueService.join({ id: "999", name: "expensive player" });
 
-    expect(result).toEqual([{ id: "999", name: "expensive player" }]);
+    expect(atheleteRepositoryAddMock).toHaveBeenCalledWith({
+      id: "999",
+      name: "expensive player",
+    });
   });
 
   test("should remove an athlete from the queue list", () => {
-    const result = queueService.leave("999");
+    queueService.leave("999");
 
-    expect(result).toEqual([]);
+    expect(atheleteRepositoryRemoveMock).toHaveBeenCalledWith("999");
+  });
+
+  test("should return the first fourth player from the queue ", () => {
+    atheleteRepositoryListMock.mockReturnValue([
+      { name: "first" },
+      { name: "second" },
+      { name: "third" },
+      { name: "fourth" },
+      { name: "fifth" },
+      { name: "sixth" },
+    ]);
+
+    const response = queueService.getFirstFour();
+
+    expect(response).toEqual([
+      { name: "first" },
+      { name: "second" },
+      { name: "third" },
+      { name: "fourth" },
+    ]);
   });
 });

--- a/src/services/queueService.ts
+++ b/src/services/queueService.ts
@@ -3,6 +3,8 @@ import { Athlete } from "../models/athleteModel.js";
 import { athleteRepository } from "../repositories/athleteRepository.js";
 
 function join(athelete: Athlete) {
+  console.log({ athelete });
+
   athleteRepository.add(athelete);
 
   return athleteRepository.list();
@@ -14,7 +16,18 @@ function leave(id: string) {
   return athleteRepository.list();
 }
 
+function getFirstFour() {
+  const queue = athleteRepository.list();
+
+  const [first, second, third, fourth] = queue;
+
+  const players = [first, second, third, fourth];
+
+  return players;
+}
+
 export const queueService = {
   join,
   leave,
+  getFirstFour,
 };

--- a/src/services/queueService.ts
+++ b/src/services/queueService.ts
@@ -3,8 +3,6 @@ import { Athlete } from "../models/athleteModel.js";
 import { athleteRepository } from "../repositories/athleteRepository.js";
 
 function join(athelete: Athlete) {
-  console.log({ athelete });
-
   athleteRepository.add(athelete);
 
   return athleteRepository.list();


### PR DESCRIPTION
# ✨ Add next game event

## Motivation
When the user joins the lobby we are going to check if there is a court and athletes available, if so we notify the client with the next four players for the next game

## Changes
- create a event constant
- add rule on lobby join handler
- add `nextGameService` file
- add `getFirstFour` in `queueService`
- add tests