### PR TITLE
♻️  Refactor courtService

### DIFF
--- a/src/handlers/connectionHandler.ts
+++ b/src/handlers/connectionHandler.ts
@@ -4,13 +4,11 @@ import { courtService } from "../services/courtService.js";
 import { queueService } from "../services/queueService.js";
 import { lobbyService } from "../services/lobbyService.js";
 
-import { court, lobby, server } from "./events.js";
+import { lobby, server } from "./events.js";
 
 export function registerConnectionHandlers(io: Server, socket: Socket) {
   function disconnect() {
-    const courtPlayers = courtService.leave(socket.id);
-
-    io.emit(court.list, courtPlayers);
+    courtService.leave(socket.id);
 
     queueService.leave(socket.id);
 

--- a/src/services/courtService.test.ts
+++ b/src/services/courtService.test.ts
@@ -1,17 +1,34 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
+
+import { Athlete } from "../models/athleteModel.js";
 
 import { courtService } from "./courtService.js";
 
+const courtRepositoryAddMock = vi.fn();
+const courtRepositoryRemoveMock = vi.fn();
+
+vi.mock("../repositories/courtRepository.js", () => {
+  return {
+    courtRepository: {
+      add: (athelete: Athlete) => courtRepositoryAddMock(athelete),
+      remove: (id: string) => courtRepositoryRemoveMock(id),
+    },
+  };
+});
+
 describe("Court Service", () => {
   test("should add an athlete in court list", () => {
-    const result = courtService.join({ id: "999", name: "expensive player" });
+    courtService.join({ id: "athlete-id", name: "expensive player" });
 
-    expect(result).toEqual([{ id: "999", name: "expensive player" }]);
+    expect(courtRepositoryAddMock).toHaveBeenCalledWith({
+      id: "athlete-id",
+      name: "expensive player",
+    });
   });
 
   test("should remove an athlete from the court list", () => {
-    const result = courtService.leave("999");
+    courtService.leave("athlete-id");
 
-    expect(result).toEqual([]);
+    expect(courtRepositoryRemoveMock).toHaveBeenCalledWith("athlete-id");
   });
 });

--- a/src/services/courtService.ts
+++ b/src/services/courtService.ts
@@ -4,14 +4,10 @@ import { courtRepository } from "../repositories/courtRepository.js";
 
 function join(player: Athlete) {
   courtRepository.add(player);
-
-  return courtRepository.list();
 }
 
 function leave(id: string) {
   courtRepository.remove(id);
-
-  return courtRepository.list();
 }
 
 export const courtService = {


### PR DESCRIPTION
# ♻️  Refactor courtService

## Motivation
The return of `join` and `leave` functions are not being used 

## Changes
- remove the return from `join` function
- remove the return from `leave` function