### PR TITLE
♻️  Refactor queueService

### DIFF
--- a/src/services/queueService.ts
+++ b/src/services/queueService.ts
@@ -4,14 +4,10 @@ import { athleteRepository } from "../repositories/athleteRepository.js";
 
 function join(athelete: Athlete) {
   athleteRepository.add(athelete);
-
-  return athleteRepository.list();
 }
 
 function leave(id: string) {
   athleteRepository.remove(id);
-
-  return athleteRepository.list();
 }
 
 function getFirstFour() {


### PR DESCRIPTION
# ♻️  Refactor queueService

## Motivation
The return of `join` and `leave` functions are not being used 

## Changes
- remove the return from `join` function
- remove the return from `leave` function